### PR TITLE
Add tracking header and bump version to v0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,7 +419,7 @@ checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "meilisearch-importer"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "byte-unit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "meilisearch-importer"
 description = "A tool to import massive datasets into Meilisearch by sending them in batches"
-version = "0.2.0"
+version = "0.2.1"
 repository = "https://github.com/meilisearch/meilisearch-importer"
 license = "MIT"
 edition = "2021"

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,6 +78,7 @@ fn send_data(
         let mut request = agent.post(&url);
         request = request.set("Content-Type", mime.as_str());
         request = request.set("Content-Encoding", "gzip");
+        request = request.set("X-Meilisearch-Client", "Meilisearch Importer");
 
         if let Some(api_key) = &api_key {
             request = request.set("Authorization", &format!("Bearer {}", api_key));


### PR DESCRIPTION
This PR sets the `x-meilisearch-client` header to track the tool's usage. It also bumps the version to v0.2.1.